### PR TITLE
Power VS: Obtain CCO image based on the host system architecture

### DIFF
--- a/powervs-ipi-scripts/ccoctl.md
+++ b/powervs-ipi-scripts/ccoctl.md
@@ -2,9 +2,11 @@
 ## Prerequisites:
 1. Access to an OpenShift Container Platform account with cluster administrator access
 2. OpenShift CLI (oc)
-3. IBM Cloud API key set in the environment using a command like
+3. A stable release of openshift-install corresponding to the host architecture.
+4. IBM Cloud API key set in the environment using a command like
 `export IBMCLOUD_API_KEY=<your IBM Cloud API key>`
-4. IBM Cloud Resource group (recommended)
+5. IBM Cloud Resource group (recommended)
+6. podman
 
 ## This script executes the following steps:
 1. Obtains the CCO container image from the OpenShift Container Platform release image.


### PR DESCRIPTION
Earlier, even if the host architecture was x86, the ppc64le version of the CCO image was downloaded making it impossible to use this script on an x86 system. This PR downloads the CCO image depending on the host system architecture.